### PR TITLE
退会者用のロジックを追加。

### DIFF
--- a/spotto_league/controllers/user/info_controller.py
+++ b/spotto_league/controllers/user/info_controller.py
@@ -13,12 +13,12 @@ class InfoController(BaseController):
     # override
     async def validate(self, request: BaseRequest, **kwargs) -> None:
         user = User.find_by_login_name(kwargs["login_name"])
-        if not user:
+        if not user or user.is_withdrawaler():
             raise Exception("{}というユーザは存在しません。".format(kwargs["login_name"]))
 
         if user.is_visitor():
             raise Exception(
-                "ビジターアカウントはの情報は見ることができません。{}の誕生日は{}だよ。".format(
+                "ビジターアカウントではこの情報を見ることができません。{}の誕生日は{}だよ。".format(
                     user.name, user.birthday_for_display
                 )
             )

--- a/spotto_league/controllers/user/post_login_controller.py
+++ b/spotto_league/controllers/user/post_login_controller.py
@@ -32,6 +32,8 @@ class PostLoginController(BaseController):
                 raise Exception("ログイン失敗")
             if not user.is_visitor():
                 raise Exception("ログイン失敗")
+            if user.is_withdrawaler():
+                raise Exception("ログイン失敗")
         # それ以外の人用validate
         elif PasswordUtil.is_correct_common_password(common_password):
             user = User.find_by_login_name(login_name)
@@ -39,7 +41,7 @@ class PostLoginController(BaseController):
                 raise Exception("ログイン失敗")
             if not PasswordUtil.is_same(password, user.password):
                 raise Exception("ログイン失敗")
-            if user.is_visitor():
+            if user.is_visitor() or user.is_withdrawaler():
                 raise Exception("ログイン失敗")
         else:
             raise Exception("ログイン失敗")

--- a/spotto_league/entities/point_rank.py
+++ b/spotto_league/entities/point_rank.py
@@ -129,7 +129,7 @@ class PointRank:
     @classmethod
     def make_point_rank_list_in_season(cls, year: int) -> List["PointRank"]:
         user_points = UserPoint.find_all_in_season(year)
-        users = User.all_without_visitor()
+        users = User.all_within_team()
         bonus_points = BonusPoint.find_all_by_user_ids([u.id for u in users])
 
         rank_list = []

--- a/spotto_league/entities/rank.py
+++ b/spotto_league/entities/rank.py
@@ -155,6 +155,7 @@ class Rank:
             "win": self.win,
             "lose": self.lose,
             "reason": self._reason,
+            "is_withdrawaler": self.user.is_withdrawaler()
         }
 
     @classmethod

--- a/spotto_league/models/role.py
+++ b/spotto_league/models/role.py
@@ -10,6 +10,7 @@ class RoleType(Enum):
     ADMIN = 1  # 管理者
     MEMBER = 2  # メンバー
     VISITOR = 3  # ビジター。機能が制限されている。
+    WITHDRAWALER = 4  # 退会した人。何も表示されないようにする。
 
     @classmethod
     def all(cls):
@@ -17,6 +18,7 @@ class RoleType(Enum):
         return [
             {"id": RoleType.ADMIN.value, "name": "管理者"},
             {"id": RoleType.MEMBER.value, "name": "メンバー"},
+            {"id": RoleType.WITHDRAWALER.value, "name": "退会者"},
         ]
 
 
@@ -56,3 +58,9 @@ class Role(db.Model, Base):
 
     def is_visitor(self) -> bool:
         return RoleType(self.role_type) == RoleType.VISITOR
+
+    def is_withdrawaler(self) -> bool:
+        return RoleType(self.role_type) == RoleType.WITHDRAWALER
+
+    def is_in_team(self) -> bool:
+        return self.is_admin() or self.is_member()

--- a/spotto_league/models/user.py
+++ b/spotto_league/models/user.py
@@ -46,6 +46,13 @@ class User(flask_login.UserMixin, db.Model, Base):
         return [u for u in users if u.id not in visitor_user_ids]
 
     @classmethod
+    def all_within_team(cls) -> List["User"]:
+        users = cls.all()
+        roles = Role.all()
+        team_user_ids = [r.user_id for r in roles if r.is_in_team()]
+        return [u for u in users if u.id in team_user_ids]
+
+    @classmethod
     def all_on_birthday(cls, month: int, day: int) -> List["User"]:
         def is_satisfy(user: User, month: int, day: int) -> bool:
             return all([month == user.birthday.month,
@@ -77,6 +84,9 @@ class User(flask_login.UserMixin, db.Model, Base):
 
     def is_visitor(self) -> bool:
         return self.role.is_visitor()
+
+    def is_withdrawaler(self) -> bool:
+        return self.role.is_withdrawaler()
 
     @property
     def unpaid(self) -> Unpaid:

--- a/templates/league/parts/after_session/personal_record.html
+++ b/templates/league/parts/after_session/personal_record.html
@@ -27,7 +27,11 @@
           {% if login_user.is_visitor() %}
           vs <span class="light-blue">{{ user.name }}</span>
           {% else %}
-          vs <a href='/user/info/{{ user.login_name }}/'>{{ user.name }}</a>
+              {% if not user.is_withdrawaler() %}
+                  vs <a href='/user/info/{{ user.login_name }}/'>{{ user.name }}</a>
+              {% else %}
+                  vs {{ user.name }}
+              {% endif %}
           {% endif %}
         </li>
         <li class="list-group-item">

--- a/templates/league/parts/after_session/point_rank.html
+++ b/templates/league/parts/after_session/point_rank.html
@@ -30,7 +30,11 @@
           {% if login_user.id == point_rank.user.id %}
           <b><a class="deep-blue" href='/user/info/{{ point_rank.user.login_name }}/'>{{ point_rank.user.name }}</a></b>
           {% else %}
-          <a href='/user/info/{{ point_rank.user.login_name }}/'>{{ point_rank.user.name }}</a>
+            {% if not point_rank.user.is_withdrawaler() %}
+              <a href='/user/info/{{ point_rank.user.login_name }}/'>{{ point_rank.user.name }}</a>
+            {% else %}
+              {{ point_rank.user.name }}
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/templates/league/parts/ranking.html
+++ b/templates/league/parts/ranking.html
@@ -27,7 +27,11 @@
             {% if login_user.id == r_user_id %}
             <b><a class="deep-blue" href='/user/info/{{ rank_hash[r_user_id]["login_name"] }}/'>{{ rank_hash[r_user_id]['user_name'] }}</a></b>
             {% else %}
-            <a href='/user/info/{{ rank_hash[r_user_id]["login_name"] }}/'>{{ rank_hash[r_user_id]['user_name'] }}</a>
+              {% if not rank_hash[r_user_id]['is_withdrawaler'] %}
+                <a href='/user/info/{{ rank_hash[r_user_id]["login_name"] }}/'>{{ rank_hash[r_user_id]['user_name'] }}</a>
+              {% else %}
+                {{ rank_hash[r_user_id]['user_name'] }}
+              {% endif %}
             {% endif %}
           {% endif %}
         </div>

--- a/templates/league/parts/th_user_name.html
+++ b/templates/league/parts/th_user_name.html
@@ -8,6 +8,10 @@
   {% if login_user.id == user.id %}
   <th class="user-name" scope="col"><a class="deep-blue" href='/user/info/{{ user.login_name }}/'>{{ user.name }}</a></th>
   {% else %}
-  <th class="user-name" scope="col"><a href='/user/info/{{ user.login_name }}/'>{{ user.name }}</a></th>
+      {% if not user.is_withdrawaler() %}
+          <th class="user-name" scope="col"><a href='/user/info/{{ user.login_name }}/'>{{ user.name }}</a></th>
+      {% else %}
+          <th class="user-name" scope="col">{{ user.name }}</th>
+      {% endif %}
   {% endif %}
 {% endif %}

--- a/templates/user/login.html
+++ b/templates/user/login.html
@@ -15,7 +15,7 @@
   {% if is_miss_login %}
   <div class="row">
     <div class="col-12">
-      <div class="alert alert-warning alert-dismissible fade show mt-4" role="alert">
+      <div class="login-error alert alert-warning alert-dismissible fade show mt-4" role="alert">
         ログインID、パスワード、秘密の合言葉のいずれかが違います。
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>

--- a/tests/config/data.yml
+++ b/tests/config/data.yml
@@ -68,6 +68,20 @@ visitor_user:
       Role:
         properties:
           role_type: 3
+withdrawaler_user:
+  User:
+    properties:
+      login_name: 'withdrawaler_onopon'
+      password: '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'
+      name: '退会おのぽん'
+      gender: 1
+      birthday: '1989-09-03'
+      first_name: 'ぽん'
+      last_name: 'おの'
+    related_classes:
+      Role:
+        properties:
+          role_type: 4
 two_guest_users:
   User:
     properties:

--- a/tests/spotto_league/controllers/user/test_info_controller.py
+++ b/tests/spotto_league/controllers/user/test_info_controller.py
@@ -1,0 +1,45 @@
+from tests.spotto_league.controllers.base_controller import BaseController
+from tests.modules.data_creator import DataCreator
+
+
+class TestInfoController(BaseController):
+    def test_get_as_success(self):
+        dc = DataCreator()
+        users = [dc.create('admin_user'), dc.create('guest_user'), dc.create('member_user')]
+        for login_user in users:
+            self.login(login_user.login_name, 'password')
+            for user in users:
+                result = self.get("/user/info/{}/".format(user.login_name))
+                assert result.status_code == 200
+            self.logout()
+
+    def test_get_as_not_login(self):
+        dc = DataCreator()
+        users = [dc.create('admin_user'), dc.create('guest_user'), dc.create('member_user')]
+        for user in users:
+            result = self.get("/user/info/{}/".format(user.login_name))
+            assert result.status_code == 302
+            assert '/user/login' in result.headers.get('Location')
+
+    def test_get_to_does_not_exist_user(self):
+        dc = DataCreator()
+        user = dc.create('admin_user')
+        self.login(user.login_name, 'password')
+        result = self.get("/user/info/{}/".format("do_not_exist_user"))
+        assert result.status_code == 404
+
+    def test_get_to_visitor_user(self):
+        dc = DataCreator()
+        user = dc.create('admin_user')
+        self.login(user.login_name, 'password')
+        visitor_user = dc.create('visitor_user')
+        result = self.get("/user/info/{}/".format(visitor_user.login_name))
+        assert result.status_code == 404
+
+    def test_get_to_withdrawaler_user(self):
+        dc = DataCreator()
+        user = dc.create('admin_user')
+        self.login(user.login_name, 'password')
+        withdrawaler_user = dc.create('withdrawaler_user')
+        result = self.get("/user/info/{}/".format(withdrawaler_user.login_name))
+        assert result.status_code == 404

--- a/tests/spotto_league/controllers/user/test_post_login_controller.py
+++ b/tests/spotto_league/controllers/user/test_post_login_controller.py
@@ -1,0 +1,52 @@
+from instance import settings
+from tests.spotto_league.controllers.base_controller import BaseController
+from tests.modules.data_creator import DataCreator
+
+
+class TestPostLoginController(BaseController):
+    def test_post_as_success(self):
+        dc = DataCreator()
+        users = [dc.create('admin_user'), dc.create('guest_user'), dc.create('member_user')]
+        for user in users:
+            args = {'login_name': user.login_name,
+                    'password': 'password',
+                    'common_password': settings.COMMON_PASSWORD}
+            result = self.post("/user/login", data=args)
+            assert result.status_code == 302
+            assert 'http://127.0.0.1/' in result.headers.get('Location')
+            self.logout()
+
+        visitor_user = dc.create('visitor_user')
+        args = {'login_name': visitor_user.login_name,
+                'password': 'password',
+                'common_password': settings.COMMON_VISITOR_PASSWORD}
+        result = self.post("/user/login", data=args)
+        assert result.status_code == 302
+        assert 'http://127.0.0.1/' in result.headers.get('Location')
+
+    def test_post_as_failed(self):
+        dc = DataCreator()
+        visitor_user = dc.create('visitor_user')
+
+        users = [dc.create('admin_user'), dc.create('guest_user'), dc.create('member_user'), dc.create('withdrawaler_user')]
+        for user in users:
+            args = {'login_name': user.login_name,
+                    'password': 'INVALID_password',
+                    'common_password': settings.COMMON_PASSWORD}
+            result = self.post("/user/login", data=args)
+            assert result.status_code == 200
+            assert 'login-error' in str(result.data)
+
+            args = {'login_name': user.login_name,
+                    'password': 'password',
+                    'common_password': settings.COMMON_VISITOR_PASSWORD}
+            result = self.post("/user/login", data=args)
+            assert result.status_code == 200
+            assert 'login-error' in str(result.data)
+
+        args = {'login_name': visitor_user.login_name,
+                'password': 'invalid_password',
+                'common_password': settings.COMMON_VISITOR_PASSWORD}
+        result = self.post("/user/login", data=args)
+        assert result.status_code == 200
+        assert 'login-error' in str(result.data)

--- a/tests/spotto_league/entities/test_rank.py
+++ b/tests/spotto_league/entities/test_rank.py
@@ -92,6 +92,16 @@ class TestRank(Base):
         assert rank_hash['win'] == rank.win
         assert rank_hash['lose'] == rank.lose
         assert rank_hash['reason'] == rank.reason
+        assert not rank_hash['is_withdrawaler']
+
+    def test_to_hash_for_withdrawaler(self):
+        user = DataCreator().create('withdrawaler_user')
+        league_member = LeagueMember.find_or_initialize_by_league_id_and_user_id(1, user.id)
+        rank = Rank(league_member, [], [])
+        rank._rank = 1
+        rank._reason = ""
+        rank_hash = rank.to_hash()
+        assert rank_hash['is_withdrawaler']
 
     def test_make_rank_list(self):
         place = DataCreator().create('place')

--- a/tests/spotto_league/models/test_role.py
+++ b/tests/spotto_league/models/test_role.py
@@ -1,5 +1,5 @@
 from tests.base import Base
-from spotto_league.models.role import RoleType
+from spotto_league.models.role import Role, RoleType
 
 
 class TestRoleType(Base):
@@ -8,5 +8,23 @@ class TestRoleType(Base):
         ids = [role_type["id"] for role_type in role_types]
         assert RoleType.ADMIN.value in ids
         assert RoleType.MEMBER.value in ids
+        assert RoleType.WITHDRAWALER.value in ids
         assert RoleType.GUEST.value not in ids
         assert RoleType.VISITOR.value not in ids
+
+    def test_is_in_team(self):
+        role = Role()
+        role.role_type = RoleType.ADMIN.value
+        assert role.is_in_team()
+
+        role.role_type = RoleType.MEMBER.value
+        assert role.is_in_team()
+
+        role.role_type = RoleType.GUEST.value
+        assert not role.is_in_team()
+
+        role.role_type = RoleType.VISITOR.value
+        assert not role.is_in_team()
+
+        role.role_type = RoleType.WITHDRAWALER.value
+        assert not role.is_in_team()

--- a/tests/spotto_league/models/test_user.py
+++ b/tests/spotto_league/models/test_user.py
@@ -23,8 +23,18 @@ class TestUser(Base):
         users_without_visitor.append(DataCreator().create('guest_user'))
         users_without_visitor.append(DataCreator().create('admin_user'))
         users_without_visitor.append(DataCreator().create('member_user'))
+        users_without_visitor.append(DataCreator().create('withdrawaler_user'))
         DataCreator().create('visitor_user')
         assert User.all_without_visitor() == users_without_visitor
+
+    def test_all_within_team(self):
+        users_without_visitor = []
+        users_without_visitor.append(DataCreator().create('admin_user'))
+        users_without_visitor.append(DataCreator().create('member_user'))
+        DataCreator().create('guest_user')
+        DataCreator().create('visitor_user')
+        DataCreator().create('withdrawaler_user')
+        assert User.all_within_team() == users_without_visitor
 
     def test_all_on_birthday(self):
         birthday_users = []
@@ -61,24 +71,35 @@ class TestUser(Base):
         assert DataCreator().create('admin_user').is_admin()
         assert not DataCreator().create('member_user').is_admin()
         assert not DataCreator().create('visitor_user').is_admin()
+        assert not DataCreator().create('withdrawaler_user').is_admin()
 
     def test_is_member(self):
         assert not DataCreator().create('guest_user').is_member()
         assert not DataCreator().create('admin_user').is_member()
         assert DataCreator().create('member_user').is_member()
         assert not DataCreator().create('visitor_user').is_member()
+        assert not DataCreator().create('withdrawaler_user').is_member()
 
     def test_is_guest(self):
         assert DataCreator().create('guest_user').is_guest()
         assert not DataCreator().create('admin_user').is_guest()
         assert not DataCreator().create('member_user').is_guest()
         assert not DataCreator().create('visitor_user').is_guest()
+        assert not DataCreator().create('withdrawaler_user').is_guest()
 
     def test_is_visitor(self):
         assert not DataCreator().create('guest_user').is_visitor()
         assert not DataCreator().create('admin_user').is_visitor()
         assert not DataCreator().create('member_user').is_visitor()
         assert DataCreator().create('visitor_user').is_visitor()
+        assert not DataCreator().create('withdrawaler_user').is_visitor()
+
+    def test_is_withdrawaler(self):
+        assert not DataCreator().create('guest_user').is_withdrawaler()
+        assert not DataCreator().create('admin_user').is_withdrawaler()
+        assert not DataCreator().create('member_user').is_withdrawaler()
+        assert not DataCreator().create('visitor_user').is_withdrawaler()
+        assert DataCreator().create('withdrawaler_user').is_withdrawaler()
 
     def test_birthday_for_display(self):
         user = User()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7286047/149996064-f7318b1f-d11a-41dc-bc98-2e4f10507598.png)
管理者ページより退会者を選択できるようにした。

# 退会したら
* 過去のリーグ戦のユーザとしては残ってるけど、リンクを踏めない状況になっている。
* 退会した人はログインできない
* 退会した人はランキングから除外される